### PR TITLE
removal of duplicate scanner module imports

### DIFF
--- a/syncdiff
+++ b/syncdiff
@@ -45,7 +45,6 @@ use SyncDiff::Config;
 use SyncDiff::Scanner;
 use SyncDiff::DB;
 use SyncDiff::File;
-use SyncDiff::Scanner;
 use SyncDiff::Server;
 use SyncDiff::Client;
 


### PR DESCRIPTION
There are two imports of scanner module in the syncdiff code which may become a bug later, So I have identified it and removed it.
