### PR TITLE
Basic Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: "perl"
 
+before_install:
+  - sudo apt-get install -y librsync-dev
+
 install:
   - cpanm -v --installdeps --notest .
-  - sudo apt-get install -y librsync-dev
 
 script: "perl Build.PL; ./Build test"
 


### PR DESCRIPTION
Enable Travis-CI tests and IRC notifications.  Right now it just ensures that Build.PL and ./Build test run without errors.
