### PR TITLE
Issue with checksum while files synchronization

### DIFF
--- a/FileSync/SyncDiff/Scanner.pm
+++ b/FileSync/SyncDiff/Scanner.pm
@@ -267,7 +267,7 @@ sub find_wanted {
 	#
 
 	# prep the object since it's obviously changed
-	$found_file_obj->checksum();
+	$found_file_obj->checksum_file();
 	$found_file_obj->last_transaction( $self->current_transaction_id() );
 
 	# update the file in the database


### PR DESCRIPTION
- checksum() is a getter for checksum attr. But in this scope we need to calculate checksum so we should call checksum_file(), because we will save an empty checksum value into DB and than we will fail synchronization on client side.